### PR TITLE
Move reporter binding to service provider

### DIFF
--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -71,7 +71,9 @@ class ExceptionHandler extends LaravelExceptionHandler
 
             $config = isset($reporter['config']) && is_array($reporter['config']) ? $reporter['config'] : [];
 
-            $reporterInstance = $this->container->make($class)($config);
+            // $this->container->make($class)($config) fails php <= 5.4
+            $reporterFactory = $this->container->make($class);
+            $reporterInstance = $reporterFactory($config);
 
             $this->reportResponses[$key] = $reporterInstance->report($e);
         }

--- a/src/ExceptionHandler.php
+++ b/src/ExceptionHandler.php
@@ -71,7 +71,7 @@ class ExceptionHandler extends LaravelExceptionHandler
 
             $config = isset($reporter['config']) && is_array($reporter['config']) ? $reporter['config'] : [];
 
-            $reporterInstance = $this->container->make($class, [$config]);
+            $reporterInstance = $this->container->make($class)($config);
 
             $this->reportResponses[$key] = $reporterInstance->report($e);
         }

--- a/src/Provider/LaravelServiceProvider.php
+++ b/src/Provider/LaravelServiceProvider.php
@@ -3,6 +3,8 @@
 namespace Optimus\Heimdal\Provider;
 
 use Illuminate\Support\ServiceProvider as BaseProvider;
+use Optimus\Heimdal\Reporters\BugsnagReporter;
+use Optimus\Heimdal\Reporters\SentryReporter;
 
 class LaravelServiceProvider extends BaseProvider {
 
@@ -10,6 +12,7 @@ class LaravelServiceProvider extends BaseProvider {
     {
         $this->loadConfig();
         $this->registerAssets();
+        $this->bindReporters();
     }
 
     private function registerAssets()
@@ -24,5 +27,20 @@ class LaravelServiceProvider extends BaseProvider {
         if ($this->app['config']->get('optimus.heimdal') === null) {
             $this->app['config']->set('optimus.heimdal', require __DIR__.'/../config/optimus.heimdal.php');
         }
+    }
+
+    private function bindReporters()
+    {
+        $this->app->bind(BugsnagReporter::class, function ($app) {
+            return function (array $config) {
+                return new BugsnagReporter($config);
+            };
+        });
+
+        $this->app->bind(SentryReporter::class, function ($app) {
+            return function (array $config) {
+                return new SentryReporter($config);
+            };
+        });
     }
 }

--- a/tests/ExceptionHandlerTest.php
+++ b/tests/ExceptionHandlerTest.php
@@ -38,6 +38,12 @@ class ExceptionHandlerTest extends TestCase {
      */
     private function createHandler()
     {
+        app()->bind(TestReporter::class, function($app){
+            return function (array $config) {
+                return new TestReporter($config);
+            };
+        });
+
         return app()->make(ExceptionHandler::class);
     }
 


### PR DESCRIPTION
Laravel removed parameters from the container make command. The
reporters can therefore not be instantiated since the config is not
passed by the container. See more here
https://github.com/laravel/internals/issues/391
We now fix this by binding the reporters in the service provider
instead.

Closes #8