### PR TITLE
Sentry options not passed correctly

### DIFF
--- a/src/Reporters/SentryReporter.php
+++ b/src/Reporters/SentryReporter.php
@@ -24,7 +24,7 @@ class SentryReporter implements ReporterInterface
 
     public function report(Exception $e)
     {
-        $options = $this->config;
+        $options = $this->config['sentry_options'];
 
         $raven = new Raven_Client(
             $this->config['dsn'],


### PR DESCRIPTION
The options sent to Sentry via Raven_Client() were not interpreted there, because the entire $config array is given instead of just the content of $config['sentry_options'].