### PR TITLE
Add headers to the Http Response

### DIFF
--- a/src/Formatters/HttpExceptionFormatter.php
+++ b/src/Formatters/HttpExceptionFormatter.php
@@ -11,6 +11,10 @@ class HttpExceptionFormatter extends ExceptionFormatter
     public function format(JsonResponse $response, Exception $e, array $reporterResponses)
     {
         parent::format($response, $e, $reporterResponses);
+        
+        if (count($headers = $e->getHeaders())) {
+            $response->headers->add($headers);
+        }
 
         $response->setStatusCode($e->getStatusCode());
     }


### PR DESCRIPTION
Can be useful in some responses, e.g "Retry-After" header in HTTP 409 Error.

I guess is related with: https://github.com/esbenp/heimdal/issues/4